### PR TITLE
Feature/#1-rss 피드 크롤러 구현

### DIFF
--- a/server/src/main/java/com/tonggn/techub/crawler/AtomParser.java
+++ b/server/src/main/java/com/tonggn/techub/crawler/AtomParser.java
@@ -1,0 +1,26 @@
+package com.tonggn.techub.crawler;
+
+import java.util.List;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+class AtomParser {
+
+  private AtomParser() {
+  }
+
+  public static List<ParseResponse> parse(final Document xml) {
+    return xml.select("feed > entry").stream()
+        .map(AtomParser::mapToResponse)
+        .toList();
+  }
+
+  private static ParseResponse mapToResponse(final Element item) {
+    final String title = ParserUtils.selectFirstTextOrEmpty(item, "title");
+    final String link = ParserUtils.selectFirstAttrOrEmpty(item, "link", "href");
+    final String description = ParserUtils.selectFirstTextOrEmpty(item, "summary");
+    final String pubDate = ParserUtils.selectFirstTextOrEmpty(item, "updated");
+    final String image = ParserUtils.selectFirstTextOrEmpty(item, "image");
+    return new ParseResponse(title, link, description, pubDate, image);
+  }
+}

--- a/server/src/main/java/com/tonggn/techub/crawler/FrontParser.java
+++ b/server/src/main/java/com/tonggn/techub/crawler/FrontParser.java
@@ -1,0 +1,34 @@
+package com.tonggn.techub.crawler;
+
+import static org.jsoup.parser.Parser.xmlParser;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FrontParser {
+
+  private final Map<RssType, Function<Document, List<ParseResponse>>> parserMap = new EnumMap<>(
+      RssType.class);
+
+  public FrontParser() {
+    parserMap.put(RssType.RSS, RssParser::parse);
+    parserMap.put(RssType.RDF, RdfParser::parse);
+    parserMap.put(RssType.ATOM, AtomParser::parse);
+  }
+
+  public List<ParseResponse> parse(final Document document) {
+    final Document xml = document.parser(xmlParser());
+    final RssType type = getRssType(xml);
+    return parserMap.get(type).apply(xml);
+  }
+
+  private RssType getRssType(final Document xml) {
+    final String rootTagName = xml.child(0).tagName();
+    return RssType.of(rootTagName);
+  }
+}

--- a/server/src/main/java/com/tonggn/techub/crawler/ParseResponse.java
+++ b/server/src/main/java/com/tonggn/techub/crawler/ParseResponse.java
@@ -1,0 +1,11 @@
+package com.tonggn.techub.crawler;
+
+public record ParseResponse(
+    String title,
+    String link,
+    String description,
+    String pubDate,
+    String image
+) {
+
+}

--- a/server/src/main/java/com/tonggn/techub/crawler/ParserUtils.java
+++ b/server/src/main/java/com/tonggn/techub/crawler/ParserUtils.java
@@ -1,0 +1,14 @@
+package com.tonggn.techub.crawler;
+
+import org.jsoup.nodes.Element;
+
+public class ParserUtils {
+
+  private ParserUtils() {
+  }
+
+  public static String selectFirstTextOrEmpty(final Element element, final String selector) {
+    final Element item = element.selectFirst(selector);
+    return item == null ? "" : item.text();
+  }
+}

--- a/server/src/main/java/com/tonggn/techub/crawler/ParserUtils.java
+++ b/server/src/main/java/com/tonggn/techub/crawler/ParserUtils.java
@@ -11,4 +11,10 @@ public class ParserUtils {
     final Element item = element.selectFirst(selector);
     return item == null ? "" : item.text();
   }
+
+  public static String selectFirstAttrOrEmpty(final Element element, final String selector,
+      final String attr) {
+    final Element item = element.selectFirst(selector);
+    return item == null ? "" : item.attr(attr);
+  }
 }

--- a/server/src/main/java/com/tonggn/techub/crawler/RdfParser.java
+++ b/server/src/main/java/com/tonggn/techub/crawler/RdfParser.java
@@ -1,0 +1,26 @@
+package com.tonggn.techub.crawler;
+
+import java.util.List;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+class RdfParser {
+
+  private RdfParser() {
+  }
+
+  public static List<ParseResponse> parse(final Document xml) {
+    return xml.select("channel > item").stream()
+        .map(RdfParser::mapToResponse)
+        .toList();
+  }
+
+  private static ParseResponse mapToResponse(final Element item) {
+    final String title = ParserUtils.selectFirstTextOrEmpty(item, "title");
+    final String link = ParserUtils.selectFirstTextOrEmpty(item, "link");
+    final String description = ParserUtils.selectFirstTextOrEmpty(item, "description");
+    final String pubDate = ParserUtils.selectFirstTextOrEmpty(item, "dc:date");
+    final String image = ParserUtils.selectFirstTextOrEmpty(item, "image");
+    return new ParseResponse(title, link, description, pubDate, image);
+  }
+}

--- a/server/src/main/java/com/tonggn/techub/crawler/RssClient.java
+++ b/server/src/main/java/com/tonggn/techub/crawler/RssClient.java
@@ -1,0 +1,21 @@
+package com.tonggn.techub.crawler;
+
+import java.io.IOException;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+public class RssClient {
+
+  private RssClient() {
+  }
+
+  public static Document request(final String url) {
+    try {
+      return Jsoup.connect(url)
+          .maxBodySize(0)
+          .get();
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to request: " + url);
+    }
+  }
+}

--- a/server/src/main/java/com/tonggn/techub/crawler/RssParser.java
+++ b/server/src/main/java/com/tonggn/techub/crawler/RssParser.java
@@ -1,0 +1,28 @@
+package com.tonggn.techub.crawler;
+
+import static com.tonggn.techub.crawler.ParserUtils.selectFirstTextOrEmpty;
+
+import java.util.List;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+class RssParser {
+
+  private RssParser() {
+  }
+
+  public static List<ParseResponse> parse(final Document xml) {
+    return xml.select("channel > item").stream()
+        .map(RssParser::mapToResponse)
+        .toList();
+  }
+
+  private static ParseResponse mapToResponse(final Element item) {
+    final String title = selectFirstTextOrEmpty(item, "title");
+    final String link = selectFirstTextOrEmpty(item, "link");
+    final String description = selectFirstTextOrEmpty(item, "description");
+    final String pubDate = selectFirstTextOrEmpty(item, "pubDate");
+    final String image = selectFirstTextOrEmpty(item, "image");
+    return new ParseResponse(title, link, description, pubDate, image);
+  }
+}

--- a/server/src/main/java/com/tonggn/techub/crawler/RssType.java
+++ b/server/src/main/java/com/tonggn/techub/crawler/RssType.java
@@ -1,0 +1,20 @@
+package com.tonggn.techub.crawler;
+
+public enum RssType {
+  RSS("rss"), ATOM("feed"), RDF("rdf:RDF");
+
+  private final String rootTagName;
+
+  RssType(final String rootTagName) {
+    this.rootTagName = rootTagName;
+  }
+
+  public static RssType of(final String rootTagName) {
+    for (final RssType type : values()) {
+      if (type.rootTagName.equals(rootTagName)) {
+        return type;
+      }
+    }
+    throw new IllegalArgumentException("Unknown root tag: " + rootTagName);
+  }
+}


### PR DESCRIPTION
이슈 사항
- rome 라이브러리를 이용해 rss 피드를 파싱할 경우 아래와 같은 오류 발생
`Invalid XML: Error on line 45: An invalid XML character (Unicode: 0xffff) was found in the CDATA section.`
따라서 Jsoup을 이용해 직접 xml 태그를 지정해 파싱하는 방법으로 구현
- rss 종류(Atom, Rss 2.0, Rss 1.0)에 따라 파싱할 수 있도록 Front Controller 패턴 적용
  - 각 Parser는 Front Controller에 의해서만 사용되도록 package private으로 선언
  - 각 Parser의 생성자가 불필요하고 유틸성 클래스이므로 `static` 메서드로 구현



close #1 